### PR TITLE
Use the l2chroot var to avoid relying on PATH

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,7 @@
   with_items: "{{ ssh_chroot_copy_extra_items }}"
 
 - name: add binary libs via l2chroot
-  command: "l2chroot {{ item.bin | default(item) }}"
+  command: "{{ ssh_chroot_l2chroot_path }} {{ item.bin | default(item) }}"
   when: item.l2chroot is not defined or item.l2chroot
   with_items: "{{ ssh_chroot_bins }}"
 


### PR DESCRIPTION
This allows l2chroot to be installed somewhere that is not on the PATH
(as the var has an absolute path). It also allows for renaming the
l2chroot script to allow multiple chroots on a system without worrying
about conflicting changes to the same script.

The same change was also implemented here:
https://github.com/gauch/ansible-role-ssh-chroot-jail/commit/4a9a34288af0f739adad5dec22c19e513ff4e10e
https://github.com/paradigmadigital/ansible-role-ssh-chroot-jail/commit/4238e4f450f6f42b823def38cefbd9eaeb19a2e5