### PR TITLE
Use systemd-tmpfiles to create devices on boot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,11 +16,18 @@ ssh_chroot_jail_dirs:
   - usr/lib64
   - home
 
+# can include type: c, b, p
+# c = char device (unbuffered) [the default]
+# b = block device (buffered)
+# p = FIFO device
+# anything else may result in errors with mknod or systemd-tmpfiles
 ssh_chroot_jail_devs:
   - {dev: 'null', major: '1', minor: '3'}
   - {dev: 'random', major: '5', minor: '0'}
   - {dev: 'urandom', major: '1', minor: '5'}
   - {dev: 'zero', major: '1', minor: '8'}
+
+ssh_chroot_tmpfiles_conf_path: /etc/tmpfiles.d/ssh-chroot.conf
 
 ssh_chroot_bins:
   - /bin/cp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,12 @@
     creates: "{{ ssh_chroot_jail_path }}/dev/{{ item.dev }}"
   with_items: "{{ ssh_chroot_jail_devs }}"
 
+- name: Ensure jail devices get created after reboot
+  template:
+    src: ssh-chroot.conf.j2
+    dest: "{{ ssh_chroot_tmpfiles_conf_path }}"
+  when: "ansible_service_mgr == 'systemd'"
+
 - name: Ensure l2chroot is installed.
   template:
     src: "{{ ssh_chroot_l2chroot_template }}"

--- a/templates/ssh-chroot.conf.j2
+++ b/templates/ssh-chroot.conf.j2
@@ -1,0 +1,3 @@
+{% for device in ssh_chroot_jail_devs %}
+{{ device.type | default('c') }} {{ ssh_chroot_jail_path }}/dev/{{ device.dev }} 0666 root root - {{ device.major }}:{{ device.minor }}
+{% endfor %}


### PR DESCRIPTION
mknod does not create persistent devices. To make a chroot that will
survive a reboot, we also need to configure systemd-tmpfiles to create
them on boot.

In order to continue supporting older or non-systemd systems, this new
task only runs when systemd is the service_mgr.

Resolves #26 