### PR TITLE
Add ability to specify which sshd_config file to update

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,9 +40,10 @@
 
 - name: Ensure SSHD config contains jail configuration.
   blockinfile:
-    path: /etc/ssh/sshd_config
+    path: "{{ ssh_chroot_sshd_config_file | default('/etc/ssh/sshd_config') }}"
     block: "{{ ssh_chroot_sshd_chroot_jail_config }}"
     insertafter: EOF
+    create: yes
   notify: restart ssh daemon
 
 - include_tasks: jail-user.yml


### PR DESCRIPTION
This allows one to utilize /etc/ssh/sshd_config.d/ directory for overwriting config that isn't the main sshd_config file.